### PR TITLE
Cleanly separate the command parser + unit testing

### DIFF
--- a/firmware/command_parser.h
+++ b/firmware/command_parser.h
@@ -11,34 +11,41 @@ namespace CommandParser {
 
   int process_int( const std::string& string,  size_t pos );
 
-	class Deltas {
-		public:
+  enum class Command {
+    Ping,
+    Abort,
+    Home,
+    Status,
+    PStatus,
+    SStatus,
+    ABSPos,
+    Sleep,
+    Wake,
+    NoCommand
+  };
 
-		Deltas() :
-			position_changed{false},
-			position_changed_arg{0},
-			new_abort{false},
-			new_home{false},
-			new_sleep{false},
-			new_awaken{false} 
-		{	}
+  constexpr int NoArg = -1;
 
-		public:
+  class CommandPacket  {
+    public:
+    CommandPacket(): command{Command::NoCommand}, optionalArg{NoArg}
+    {
+    }
+    CommandPacket( Command c ): command{c}, optionalArg{NoArg}
+    {
+    }
+    CommandPacket( Command c, int o ): command{c}, optionalArg{o}
+    {
+    }
 
-    /// @brief true if the client requested a position change, false otherwise
-		bool position_changed;
-    /// @brief if position_change is true, position_change_arg is the new
-    ///        position.
-		int  position_changed_arg;
-    /// @brief True if the client requested an abort, false otherwise.
-		bool new_abort;
-    /// @brief True if the client requested a home, false otherwise
-		bool new_home;
-    /// @brief True if the client wants to go into low power mode
-		bool new_sleep;
-    /// @brief True if the client wants to go to wake from low power mode
-		bool new_awaken;
-	};
+    bool operator==( const CommandPacket &rhs ) const 
+    {
+      return rhs.command == command && rhs.optionalArg == optionalArg;
+    }
+
+    Command command;
+    int optionalArg;
+  };
 
   /// @brief Get commands from the network interface
   ///
@@ -52,12 +59,9 @@ namespace CommandParser {
   /// - Error handling (has none).
   /// - Move extra parameters used by the STATUS command.
   ///
-  const Deltas checkForCommands( 
+  const CommandPacket checkForCommands( 
     DebugInterface& log,				// Input: Debug Log Strem
-    NetInterface& netInterface,	// Input: Network Interface
-    int focuser_position,  			// Input: For STATUS command.  TODO, move
-    const char *state, 					// Input: For STATUS command.  TODO, move
-    int state_arg  							// Input: For STATUS command.  TODO, move
+    NetInterface& netInterface	// Input: Network Interface
   );
 
 };

--- a/firmware_sim/main.cpp
+++ b/firmware_sim/main.cpp
@@ -36,6 +36,7 @@ class NetInterfaceSim: public NetInterface {
   }
   NetInterface& operator<<( char c )
   {
+    std::cout << c;
     return *this;
   }
 };
@@ -66,10 +67,11 @@ class DebugInterfaceSim: public DebugInterface
 {
   void rawWrite( const char* bytes, std::size_t numBytes ) override
   {
-    for ( int i=0; i<numBytes; ++i )
-    {
-      std::cout << bytes[i];
-    }
+    // Ignore for now.
+    //for ( int i=0; i<numBytes; ++i )
+    //{
+    //  std::cout << bytes[i];
+    //}
   }
 };
 

--- a/unit_tests/test_check_for_commands.cpp
+++ b/unit_tests/test_check_for_commands.cpp
@@ -1,15 +1,78 @@
 #include <gtest/gtest.h>
 
 #include "command_parser.h"
+#include "test_mocks.h"
+
+namespace CommandParser
+{
 
 TEST( COMMAND_PARSER, should_process_int )
 {
-  ASSERT_EQ( CommandParser::process_int( std::string("123") , 0 ), 123 );
-  ASSERT_EQ( CommandParser::process_int( std::string("123") , 1 ), 23 );
-  ASSERT_EQ( CommandParser::process_int( std::string("123") , 2 ), 3 );
-  ASSERT_EQ( CommandParser::process_int( std::string("123 "), 2 ), 3 );
-  ASSERT_EQ( CommandParser::process_int( std::string("4567890") , 0 ), 4567890);
-  ASSERT_EQ( CommandParser::process_int( std::string("cheese") , 0 ), 0 );
-  ASSERT_EQ( CommandParser::process_int( std::string("ABS_POS=500") , 8 ), 500 );
+  ASSERT_EQ( process_int( std::string("123") , 0 ), 123 );
+  ASSERT_EQ( process_int( std::string("123") , 1 ), 23 );
+  ASSERT_EQ( process_int( std::string("123") , 2 ), 3 );
+  ASSERT_EQ( process_int( std::string("123 "), 2 ), 3 );
+  ASSERT_EQ( process_int( std::string("4567890") , 0 ), 4567890);
+  ASSERT_EQ( process_int( std::string("cheese") , 0 ), 0 );
+  ASSERT_EQ( process_int( std::string("ABS_POS=500") , 8 ), 500 );
+  ASSERT_EQ( process_int( std::string("ABS_POS") , 8 ), 0 );
+  ASSERT_EQ( process_int( std::string("ABS_POS") , 7 ), 0 );
+}
+
+TEST( COMMAND_PARSER, checkForCommands)
+{
+  DebugInterfaceIgnoreMock dbgmock;
+
+  NetMockEmpty noInput;
+  ASSERT_EQ( checkForCommands( dbgmock, noInput ), CommandPacket() );
+
+  NetMockSimple junk("junk");
+  ASSERT_EQ( checkForCommands(dbgmock, junk), CommandPacket());
+
+  NetMockSimple ping("PING");
+  ASSERT_EQ( checkForCommands(dbgmock, ping), CommandPacket( Command::Ping ));
+
+  NetMockSimple abort("abort");
+  ASSERT_EQ( checkForCommands(dbgmock, abort), CommandPacket( Command::Abort));
+
+  NetMockSimple home("hOmE");
+  ASSERT_EQ( checkForCommands(dbgmock, home), CommandPacket( Command::Home));
+
+  NetMockSimple status("status with trailing garbage");
+  ASSERT_EQ( checkForCommands(dbgmock, status), CommandPacket( Command::Status));
+
+  NetMockSimple pstatus("PStatus");
+  ASSERT_EQ( checkForCommands(dbgmock, pstatus), CommandPacket( Command::PStatus ));
+
+  NetMockSimple sstatus("sstatus");
+  ASSERT_EQ( checkForCommands(dbgmock, sstatus), CommandPacket( Command::SStatus ));
+
+  // Argument defaults to 0 if not given
+  NetMockSimple abs_pos0("ABS_POS");
+  ASSERT_EQ( checkForCommands(dbgmock, abs_pos0), CommandPacket( Command::ABSPos, 0));
+
+  NetMockSimple abs_pos1("ABS_POS=100");
+  ASSERT_EQ( checkForCommands(dbgmock, abs_pos1), CommandPacket( Command::ABSPos, 100));
+
+  NetMockSimple abs_pos2("ABS_POS 100");
+  ASSERT_EQ( checkForCommands(dbgmock, abs_pos2), CommandPacket( Command::ABSPos, 100));
+
+  // Sadly, whitespace matters
+  NetMockSimple abs_pos3("ABS_POS  100");
+  ASSERT_EQ( checkForCommands(dbgmock, abs_pos3), CommandPacket( Command::ABSPos, 0));
+
+  // Negatives not supported
+  NetMockSimple abs_pos4("ABS_POS -100");
+  ASSERT_EQ( checkForCommands(dbgmock, abs_pos4), CommandPacket( Command::ABSPos, 0));
+
+  NetMockSimple sleep("sleep");
+  ASSERT_EQ( checkForCommands(dbgmock, sleep), CommandPacket( Command::Sleep ));
+
+  NetMockSimple wake("wake");
+  ASSERT_EQ( checkForCommands(dbgmock, wake), CommandPacket( Command::Wake ));
+
+
+}
+
 }
 

--- a/unit_tests/test_mocks.h
+++ b/unit_tests/test_mocks.h
@@ -1,0 +1,67 @@
+#include <iostream>
+#include <memory>
+#include <unistd.h>
+
+#include "focuser_state.h"
+#include "hardware_interface.h"
+
+class NetInterfaceMockBase: public NetInterface 
+{
+  public:
+
+  void reset() override
+  {
+  }
+  void setup( DebugInterface& debugLog ) override
+  {
+  }
+  virtual bool getString( WifiDebugOstream& log, std::string& input ) override = 0;
+  virtual NetInterface& operator<<( char c ) override = 0;
+};
+
+class NetMockEmpty: public NetInterfaceMockBase
+{
+  public:
+
+  bool getString( WifiDebugOstream& log, std::string& input ) override
+  {
+    return false;
+  }
+  NetInterface& operator<<( char c ) override 
+  {
+  }
+};
+
+class NetMockSimple: public NetInterfaceMockBase
+{
+  public:
+
+  NetMockSimple( const char* string ): payload{ std::string(string) }
+  {
+  }
+
+  bool getString( WifiDebugOstream& log, std::string& input ) override
+  {
+    input = payload;
+    return true;
+  }
+  NetInterface& operator<<( char c ) override 
+  {
+  }
+
+  private:
+  std::string payload;
+};
+
+
+class DebugInterfaceIgnoreMock: public DebugInterface
+{
+  public:
+  void rawWrite( const char* bytes, std::size_t numBytes ) override
+  {
+    // Do Nothing;
+  }
+};
+
+
+


### PR DESCRIPTION
- Move status out of the command parser
- Remove 'deltas' and replace with a 'command packet'
- Update focuser_state.cpp
- Add some simple mocks for unit testing
- Unit test command parser cases
- Change the simulator so it prints network activity instead of debug logs.